### PR TITLE
Feat/quiz history

### DIFF
--- a/src/quiz/quiz-participation.repository.ts
+++ b/src/quiz/quiz-participation.repository.ts
@@ -81,9 +81,9 @@ export class QuizParticipationRepository {
         });
     }
 
-    async getUserParticipationStats(userId: string) {
+    async getUserParticipationStats(username: string) {
         const participations = await this.PrismaService.quizParticipation.findMany({
-            where: { userId },
+            where: { user: { username } },
             select: {
                 score: true,
                 finishedAt: true,

--- a/src/quiz/quiz-participation.repository.ts
+++ b/src/quiz/quiz-participation.repository.ts
@@ -1,0 +1,157 @@
+import { PrismaService } from "src/prisma/prisma.service";
+import { Injectable } from "@nestjs/common";
+
+export interface PlayerAnswer {
+    questionIndex: number;
+    selectedOption: number;
+    isCorrect: boolean;
+}
+
+@Injectable()
+export class QuizParticipationRepository {
+    constructor(private readonly PrismaService: PrismaService) {}
+
+    async createParticipation(userId: string, quizId: string) {
+        return await this.PrismaService.quizParticipation.create({
+            data: {
+                userId,
+                quizId,
+                answers: [],
+                score: 0,
+            },
+        });
+    }
+
+    async updateParticipationScore(userId: string, quizId: string, score: number, answers: PlayerAnswer[]) {
+        // Converter as respostas para um formato JSON válido
+        const answersData = {
+            answers: answers.map(answer => ({
+                questionIndex: answer.questionIndex,
+                selectedOption: answer.selectedOption,
+                isCorrect: answer.isCorrect,
+            }))
+        };
+
+        return await this.PrismaService.quizParticipation.update({
+            where: {
+                userId_quizId: {
+                    userId,
+                    quizId,
+                },
+            },
+            data: {
+                score,
+                answers: answersData,
+                finishedAt: new Date(),
+            },
+        });
+    }
+
+    async findParticipation(userId: string, quizId: string) {
+        return await this.PrismaService.quizParticipation.findUnique({
+            where: {
+                userId_quizId: {
+                    userId,
+                    quizId,
+                },
+            },
+        });
+    }
+
+    async getUserParticipations(userId: string) {
+        return await this.PrismaService.quizParticipation.findMany({
+            where: { userId },
+            include: {
+                quiz: {
+                    select: {
+                        id: true,
+                        roomId: true,
+                        theme: true,
+                        numberOfQuestions: true,
+                        createdAt: true,
+                        User: {
+                            select: {
+                                username: true,
+                            },
+                        },
+                    },
+                },
+            },
+            orderBy: { joinedAt: 'desc' },
+        });
+    }
+
+    async getUserParticipationStats(userId: string) {
+        const participations = await this.PrismaService.quizParticipation.findMany({
+            where: { userId },
+            select: {
+                score: true,
+                finishedAt: true,
+                answers: true,
+            },
+        });
+
+        const totalParticipations = participations.length;
+        const totalScore = participations.reduce((sum, p) => sum + p.score, 0);
+        const averageScore = totalParticipations > 0 ? totalScore / totalParticipations : 0;
+        const completedQuizzes = participations.filter(p => p.finishedAt !== null).length;
+
+        // Calcular taxa de acertos
+        let totalQuestions = 0;
+        let totalCorrectAnswers = 0;
+
+        participations.forEach(participation => {
+            if (participation.finishedAt && participation.answers) {
+                const answersData = participation.answers as any;
+                if (answersData.answers && Array.isArray(answersData.answers)) {
+                    totalQuestions += answersData.answers.length;
+                    totalCorrectAnswers += answersData.answers.filter((answer: any) => answer.isCorrect).length;
+                }
+            }
+        });
+
+        const accuracyRate = totalQuestions > 0 ? (totalCorrectAnswers / totalQuestions) * 100 : 0;
+
+        return {
+            totalParticipations,
+            totalScore,
+            averageScore: Math.round(averageScore * 100) / 100,
+            completedQuizzes,
+            quizzesInProgress: totalParticipations - completedQuizzes,
+            totalQuestions,
+            totalCorrectAnswers,
+            accuracyRate: Math.round(accuracyRate * 100) / 100,
+        };
+    }
+
+    async getUserAccuracyRate(userId: string) {
+        const participations = await this.PrismaService.quizParticipation.findMany({
+            where: { userId },
+            select: {
+                answers: true,
+                finishedAt: true,
+            },
+        });
+
+        let totalQuestions = 0;
+        let totalCorrectAnswers = 0;
+
+        participations.forEach(participation => {
+            if (participation.finishedAt && participation.answers) {
+                const answersData = participation.answers as any;
+                if (answersData.answers && Array.isArray(answersData.answers)) {
+                    totalQuestions += answersData.answers.length;
+                    totalCorrectAnswers += answersData.answers.filter((answer: any) => answer.isCorrect).length;
+                }
+            }
+        });
+
+        const accuracyRate = totalQuestions > 0 ? (totalCorrectAnswers / totalQuestions) * 100 : 0;
+
+        return {
+            totalQuestions,
+            totalCorrectAnswers,
+            accuracyRate: Math.round(accuracyRate * 100) / 100, // Arredonda para 2 casas decimais
+        };
+    }
+} 

--- a/src/quiz/quiz-participation.repository.ts
+++ b/src/quiz/quiz-participation.repository.ts
@@ -58,23 +58,21 @@ export class QuizParticipationRepository {
         });
     }
 
-    async getUserParticipations(userId: string) {
+    async getUserParticipationsWithCreator(userId: string) { //Retorna uma lista de todos os quizzes que o usuario participou.
         return await this.PrismaService.quizParticipation.findMany({
             where: { userId },
             include: {
                 quiz: {
                     select: {
-                        id: true,
-                        roomId: true,
                         theme: true,
                         numberOfQuestions: true,
                         createdAt: true,
-                        User: {
+                        User: { // Criador do quiz
                             select: {
                                 username: true,
-                            },
-                        },
-                    },
+                            }
+                        }
+                    }
                 },
             },
             orderBy: { joinedAt: 'desc' },

--- a/src/quiz/quiz-participation.service.ts
+++ b/src/quiz/quiz-participation.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { QuizParticipationRepository, PlayerAnswer } from './quiz-participation.repository';
+import { QuizRepository } from './quiz.repository';
+
+@Injectable()
+export class QuizParticipationService {
+    constructor(
+        private readonly participationRepository: QuizParticipationRepository,
+        private readonly quizRepository: QuizRepository
+    ) {}
+
+    async joinQuiz(userId: string, quizId: string) {
+        // Verificar se já participou deste quiz
+        const existingParticipation = await this.participationRepository.findParticipation(userId, quizId);
+        
+        if (existingParticipation) {
+            return existingParticipation; // Retorna participação existente
+        }
+
+        // Criar nova participação
+        return await this.participationRepository.createParticipation(userId, quizId);
+    }
+
+    async finishQuiz(userId: string, quizId: string, score: number, answers: PlayerAnswer[]) {
+        return await this.participationRepository.updateParticipationScore(userId, quizId, score, answers);
+    }
+
+    async getUserParticipations(userId: string) {
+        return await this.participationRepository.getUserParticipations(userId);
+    }
+
+    async getUserStats(userId: string) {
+        return await this.participationRepository.getUserParticipationStats(userId);
+    }
+
+    async getUserAccuracyRate(userId: string) {
+        return await this.participationRepository.getUserAccuracyRate(userId);
+    }
+
+    async getParticipation(userId: string, quizId: string) {
+        return await this.participationRepository.findParticipation(userId, quizId);
+    }
+
+    async getUserQuizzes(userId: string) {
+        return await this.quizRepository.findQuizzesByUserId(userId);
+    }
+} 

--- a/src/quiz/quiz-participation.service.ts
+++ b/src/quiz/quiz-participation.service.ts
@@ -26,7 +26,17 @@ export class QuizParticipationService {
     }
 
     async getUserParticipations(userId: string) {
-        return await this.participationRepository.getUserParticipations(userId);
+        // return await this.participationRepository.getUserParticipationsWithCreator(userId);
+
+        const participations = await this.participationRepository.getUserParticipationsWithCreator(userId);
+        const quizzes = participations.map(p => ({
+            theme: p.quiz.theme,
+            numberOfQuestions: p.quiz.numberOfQuestions,
+            createdAt: p.quiz.createdAt,
+            createdByUser: p.quiz.User.username,
+        }));
+        return quizzes;
+
     }
 
     async getUserStats(username: string) {

--- a/src/quiz/quiz-participation.service.ts
+++ b/src/quiz/quiz-participation.service.ts
@@ -29,8 +29,8 @@ export class QuizParticipationService {
         return await this.participationRepository.getUserParticipations(userId);
     }
 
-    async getUserStats(userId: string) {
-        return await this.participationRepository.getUserParticipationStats(userId);
+    async getUserStats(username: string) {
+        return await this.participationRepository.getUserParticipationStats(username);
     }
 
     async getUserAccuracyRate(userId: string) {

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -10,11 +10,6 @@ export class QuizController {
         return this.quizService.generateQuiz(theme, questionNumber, userId);
     }
 
-    @Get('user/:userId')
-    getQuizzesByUserId(@Param('userId') userId: string) {
-        return this.quizService.getQuizzesByUserId(userId);
-    }
-
     @Get('room/:roomId')
     getQuizWithCreator(@Param('roomId') roomId: string) {
         return this.quizService.getQuizWithCreator(roomId);

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -1,6 +1,5 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param } from '@nestjs/common';
 import { QuizService } from './quiz.service';
-
 
 @Controller('quiz')
 export class QuizController {
@@ -9,5 +8,15 @@ export class QuizController {
     @Post()
     getQuiz(@Body('theme') theme: string, @Body('questionNumber') questionNumber: number, @Body('userId') userId: string) {
         return this.quizService.generateQuiz(theme, questionNumber, userId);
+    }
+
+    @Get('user/:userId')
+    getQuizzesByUserId(@Param('userId') userId: string) {
+        return this.quizService.getQuizzesByUserId(userId);
+    }
+
+    @Get('room/:roomId')
+    getQuizWithCreator(@Param('roomId') roomId: string) {
+        return this.quizService.getQuizWithCreator(roomId);
     }
 }

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -5,10 +5,11 @@ import { LlmService } from 'src/llm/llm.service';
 import { QuizController } from './quiz.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { QuizRepository } from './quiz.repository';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
   providers: [QuizGateway, QuizService, LlmService, QuizRepository],
   controllers: [QuizController],
-  imports: [PrismaModule],
+  imports: [PrismaModule, UserModule],
 })
 export class QuizModule {}

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { QuizService } from './quiz.service';
 import { QuizGateway } from './quiz.gateway';
 import { LlmService } from 'src/llm/llm.service';
@@ -6,10 +6,13 @@ import { QuizController } from './quiz.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { QuizRepository } from './quiz.repository';
 import { UserModule } from 'src/user/user.module';
+import { QuizParticipationRepository } from './quiz-participation.repository';
+import { QuizParticipationService } from './quiz-participation.service';
 
 @Module({
-  providers: [QuizGateway, QuizService, LlmService, QuizRepository],
+  providers: [QuizGateway, QuizService, LlmService, QuizRepository, QuizParticipationRepository, QuizParticipationService],
   controllers: [QuizController],
-  imports: [PrismaModule, UserModule],
+  imports: [PrismaModule, forwardRef(() => UserModule)],
+  exports: [QuizRepository, QuizParticipationService],
 })
 export class QuizModule {}

--- a/src/quiz/quiz.repository.ts
+++ b/src/quiz/quiz.repository.ts
@@ -1,7 +1,62 @@
 import { PrismaService } from "src/prisma/prisma.service";
 import { Injectable } from "@nestjs/common";
+import { Quiz } from "./entities/quiz.entity";
 
 @Injectable()
 export class QuizRepository {
     constructor(private readonly PrismaService: PrismaService) {}
+
+    async saveQuiz(roomId: string, quiz: Quiz, createdById: string) {
+        // Converter o quiz completo para um formato JSON válido
+        const quizData = {
+            theme: quiz.theme,
+            numQuestions: quiz.numQuestions,
+            questions: quiz.questions.map(q => ({
+                displayId: q.displayId,
+                statement: q.statement,
+                options: q.options,
+                correctOption: q.correctOption,
+                justification: q.justification
+            }))
+        };
+
+        const quizRecord = await this.PrismaService.quiz.create({
+            data: {
+                roomId,
+                theme: quiz.theme,
+                numberOfQuestions: quiz.numQuestions,
+                quizData, // Quiz completo como JSON
+                createdById,
+            },
+        });
+        return quizRecord;
+    }
+
+    async findQuizByRoomId(roomId: string) {
+        return await this.PrismaService.quiz.findUnique({
+            where: { roomId },
+        });
+    }
+
+    async findQuizzesByUserId(userId: string) {
+        return await this.PrismaService.quiz.findMany({
+            where: { createdById: userId },
+            orderBy: { createdAt: 'desc' },
+        });
+    }
+
+    async findQuizWithCreator(roomId: string) {
+        return await this.PrismaService.quiz.findUnique({
+            where: { roomId },
+            include: {
+                User: {
+                    select: {
+                        id: true,
+                        username: true,
+                        email: true,
+                    }
+                }
+            }
+        });
+    }
 }

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -16,4 +16,12 @@ export class QuizService {
     console.log(quiz); 
     return quiz;
   }
+
+  async getQuizzesByUserId(userId: string) {
+    return await this.QuizRepository.findQuizzesByUserId(userId);
+  }
+
+  async getQuizWithCreator(roomId: string) {
+    return await this.QuizRepository.findQuizWithCreator(roomId);
+  }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -26,11 +26,21 @@ export class UserController {
   }
 
   @Get('email')
-  findOneByEmail(@Query('email') id: string) {
-    return this.userService.findOneByEmail(id);
+  findOneByEmailQuery(@Query('email') email: string) {
+    return this.userService.findOneByEmail(email);
   }
 
-  @Get(':id')
+  @Get('email/:email')
+  findOneByEmailParam(@Param('email') email: string) {
+    return this.userService.findOneByEmail(email);
+  }
+
+  @Get(':username')
+  findOneByUsername(@Param('username') username: string) {
+    return this.userService.findOneByUsername(username);
+  }
+  
+  @Get('id/:id')
   findOneById(@Param('id') id: string) {
     return this.userService.findOneById(id);
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -35,11 +35,11 @@ export class UserController {
     return this.userService.findOneById(id);
   }
 
-  @Get(':id/stats')
-  async getUserStats(@Param('id') id: string) {
-    const stats = await this.userService.getUserStats(id);
+  @Get(':username/stats')
+  async getUserStats(@Param('username') username: string) {
+    const stats = await this.userService.getUserStats(username);
     return {
-      userId: id,
+      user: username,
       stats,
     };
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -35,6 +35,42 @@ export class UserController {
     return this.userService.findOneById(id);
   }
 
+  @Get(':id/stats')
+  async getUserStats(@Param('id') id: string) {
+    const stats = await this.userService.getUserStats(id);
+    return {
+      userId: id,
+      stats,
+    };
+  }
+
+  @Get(':id/participations') //Quizzes que o usuário participou
+  async getUserParticipations(@Param('id') id: string) {
+    const participations = await this.userService.getUserParticipations(id);
+    return {
+      userId: id,
+      participations,
+    };
+  }
+
+  @Get(':id/accuracy')
+  async getUserAccuracyRate(@Param('id') id: string) {
+    const accuracy = await this.userService.getUserAccuracyRate(id);
+    return {
+      userId: id,
+      accuracy,
+    };
+  }
+
+  @Get(':id/quizzes') // Quizzes criados pelo usuário
+  async getUserQuizzes(@Param('id') id: string) {
+    const quizzes = await this.userService.getUserQuizzes(id);
+    return {
+      userId: id,
+      quizzes,
+    };
+  }
+
   // @Patch(':id')
   // update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
   //   return this.userService.update(+id, updateUserDto);

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,13 +1,15 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { UserRepository } from './user.repository';
+import { QuizParticipationRepository } from '../quiz/quiz-participation.repository';
+import { QuizModule } from '../quiz/quiz.module';
 
 @Module({
   controllers: [UserController],
-  providers: [UserService, UserRepository],
-  imports: [PrismaModule],
+  providers: [UserService, UserRepository, QuizParticipationRepository],
+  imports: [PrismaModule, forwardRef(() => QuizModule)],
   exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -36,6 +36,13 @@ export class UserRepository{
         return user;
     }
 
+    async findUserByUsername(username: string) {
+        const user = await this.PrismaService.user.findFirst({
+        where: { username },
+        });
+        return user;
+    }
+
     async deleteUser(id: string) {
         await this.PrismaService.user.delete({
         where: { id },

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,10 +3,14 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
 import { UserRepository } from './user.repository';
+import { QuizParticipationService } from '../quiz/quiz-participation.service';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository : UserRepository) {}
+  constructor(
+    private readonly userRepository : UserRepository,
+    private readonly participationService: QuizParticipationService
+  ) {}
 
   async create(createUserDto: CreateUserDto) {
     await this.userRepository.findUserByEmail(createUserDto.email).then((user) => {
@@ -33,6 +37,22 @@ export class UserService {
 
   findOneByUsername(username: string) {
     return this.userRepository.findUserByUsername(username);
+  }
+
+  async getUserStats(userId: string) {
+    return await this.participationService.getUserStats(userId);
+  }
+
+  async getUserParticipations(userId: string) {
+    return await this.participationService.getUserParticipations(userId);
+  }
+
+  async getUserAccuracyRate(userId: string) {
+    return await this.participationService.getUserAccuracyRate(userId);
+  }
+
+  async getUserQuizzes(userId: string) {
+    return await this.participationService.getUserQuizzes(userId);
   }
 
   // update(id: number, updateUserDto: UpdateUserDto) {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -31,6 +31,10 @@ export class UserService {
     return this.userRepository.findUserByEmail(email);
   }
 
+  findOneByUsername(username: string) {
+    return this.userRepository.findUserByUsername(username);
+  }
+
   // update(id: number, updateUserDto: UpdateUserDto) {
   //   return `This action updates a #${id} user`;
   // }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -39,8 +39,8 @@ export class UserService {
     return this.userRepository.findUserByUsername(username);
   }
 
-  async getUserStats(userId: string) {
-    return await this.participationService.getUserStats(userId);
+  async getUserStats(username: string) {
+    return await this.participationService.getUserStats(username);
   }
 
   async getUserParticipations(userId: string) {


### PR DESCRIPTION
Essa branch foi criado no intuito de adicionar funcionalidades que permitam retornar, por meio de endpoints, os históricos de quiz de um usuário, além de algumas estatísticas importantes.

Para isso:
- Foi adicionado um novo campo no banco de dados chamado **QuizParticipation** que faz a correlação entre os usuários e os quizzes jogados.
- Criado um service e repository para QuizParticipation que cuidam da adição dos novos campos e das queries que retornam os dados correlacionado de usuário e quiz.
- Modificado os controllers de quiz e user para receber as novas rotas.